### PR TITLE
ci(lite): add cloudfront function rewrites for lite SPA

### DIFF
--- a/.github/workflows/s3-deploy.yaml
+++ b/.github/workflows/s3-deploy.yaml
@@ -54,6 +54,9 @@ jobs:
       - name: Deploy lightweight app on s3
         run: ./scripts/deploy.sh lightweight ${{ vars.S3_BUCKET_PRODUCTION }}
 
+      - name: Deploy CloudFront Function (SPA rewrite)
+        run: ./scripts/deploy-cloudfront-function.sh ${{ vars.CLOUDFRONT_DISTRIBUTION_ID }} "lite-app-rewrites" "apps/lightweight/cloudfront.js"
+
       - name: Clean production cache
         run: |
           aws cloudfront create-invalidation --paths "/*" --distribution-id $DISTRIBUTION | \

--- a/apps/lightweight/cloudfront.js
+++ b/apps/lightweight/cloudfront.js
@@ -1,0 +1,7 @@
+async function handler(event) {
+  const req = event.request;
+  if (!req.uri.includes(".")) {
+    req.uri = "/index.html";
+  }
+  return req;
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -8,7 +8,7 @@ import eslintPluginPrettierRecommended from "eslint-plugin-prettier/recommended"
 import { createNextImportResolver } from "eslint-import-resolver-next";
 
 export default tseslint.config(
-  { ignores: ["**/dist", "**/fleek.config.ts", "vitest.workspace.ts"] },
+  { ignores: ["**/dist", "**/fleek.config.ts", "vitest.workspace.ts", "**/cloudfront.js"] },
   eslint.configs.recommended,
   {
     extends: [

--- a/scripts/deploy-cloudfront-function.sh
+++ b/scripts/deploy-cloudfront-function.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+set -euo pipefail
+
+distributionId=$1
+functionName=$2
+sourceFile=$3
+
+# 1. Create or update -> DEVELOPMENT
+if aws cloudfront describe-function --name "$functionName" >/dev/null 2>&1; then
+  echo "[CloudFront Function] Updating $functionName"
+  etag=$(aws cloudfront describe-function --name "$functionName" \
+          --query 'ETag' --output text)
+  aws cloudfront update-function \
+    --name "$functionName" \
+    --if-match "$etag" \
+    --function-code "file://$sourceFile" \
+    --function-config 'Comment=Lite App Fn,Runtime=cloudfront-js-1.0'
+else
+  echo "[CloudFront Function] Creating $functionName"
+  aws cloudfront create-function \
+    --name "$functionName" \
+    --function-code "file://$sourceFile" \
+    --function-config 'Comment=Lite App Fn,Runtime=cloudfront-js-1.0'
+fi
+
+# 2. Publish -> LIVE
+liveEtag=$(aws cloudfront describe-function --name "$functionName" \
+            --query 'ETag' --output text)
+aws cloudfront publish-function --name "$functionName" --if-match "$liveEtag"
+
+# 3. Attach on viewer‑request
+funcArn=$(aws cloudfront describe-function --name "$functionName" \
+           --query 'FunctionSummary.FunctionMetadata.FunctionARN' --output text)
+
+aws cloudfront get-distribution-config --id "$distributionId" --output json > dist.json
+distEtag=$(jq -r '.ETag' dist.json)
+
+# merge / replace viewer‑request association
+jq --arg arn "$funcArn" '
+  .DistributionConfig.DefaultCacheBehavior.FunctionAssociations
+  |= (
+       .Items |= (map(select(.EventType!="viewer-request")) + [{EventType:"viewer-request",FunctionARN:$arn}])
+       | .Quantity = (.Items | length)
+     )
+  | .DistributionConfig
+' dist.json > dist-updated.json   # <- only the inner object
+
+aws cloudfront update-distribution \
+  --id "$distributionId" \
+  --if-match "$distEtag" \
+  --distribution-config file://dist-updated.json
+
+echo "[CloudFront Function] Attached $functionName ✔"


### PR DESCRIPTION
This won't work without the `cloudfront:CreateFunction` permission, which the CI currently does not have. I don't have any AWS credentials either, so I'm unable to test this, but o3 says it'll work -- make of that what you will.

Closes INTEG-2236