### PR TITLE
chore(uikit): add tsTON token icon URL

### DIFF
--- a/packages/uikit/src/lib/utils.ts
+++ b/packages/uikit/src/lib/utils.ts
@@ -98,6 +98,8 @@ export function getTokenSymbolURI(symbol: string | undefined): Token["imageSrc"]
     return "https://assets.coingecko.com/coins/images/53705/standard/usdt0.jpg";
   } else if (symbol === "TON") {
     return "https://s2.coinmarketcap.com/static/img/coins/64x64/11419.png";
+  } else if (symbol === "tsTON") {
+    return "https://s2.coinmarketcap.com/static/img/coins/64x64/38450.png";
   }
   return `https://cdn.morpho.org/assets/logos/${encodeURIComponent((symbol ?? "").toLowerCase())}.svg`;
 }


### PR DESCRIPTION
Mostly closes PRIME-1003 -- curator requested updating "vault logo" but there's no such thing -- the leftmost icon in the row is just the deposit token. But this change will properly show the tsTON token as collateral for that vault.