### PR TITLE
chore(fallback): add deprecation banner for non-full-support chains

### DIFF
--- a/apps/fallback/src/app/dashboard/page.tsx
+++ b/apps/fallback/src/app/dashboard/page.tsx
@@ -1,8 +1,10 @@
 import MorphoLogoSvg from "@morpho-org/uikit/assets/morpho.svg?react";
 import { Button } from "@morpho-org/uikit/components/shadcn/button";
 import { WalletMenu } from "@morpho-org/uikit/components/wallet-menu";
+import { getChainSlug } from "@morpho-org/uikit/lib/utils";
 import { ExternalLink } from "lucide-react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
+import { useChains } from "wagmi";
 
 import { BorrowSubPage } from "./borrow-subpage";
 import { EarnSubPage } from "./earn-subpage";
@@ -20,9 +22,15 @@ export default function Page() {
   const [selectedSubPage, setSelectedSubPage] = useState(SubPage.Earn);
   const [selectedChainSlug, setSelectedChainSlug] = useState("ethereum");
 
+  const chains = useChains();
+  const selectedChainId = useMemo(
+    () => chains.find((chain) => getChainSlug(chain) === selectedChainSlug)?.id,
+    [chains, selectedChainSlug],
+  );
+
   return (
     <div className="bg-gray-200 dark:bg-neutral-900">
-      <Header className="flex items-center justify-between px-5 py-3">
+      <Header className="flex items-center justify-between px-5 py-3" chainId={selectedChainId}>
         <div className="flex gap-4">
           <div className="text-primary-foreground flex items-center gap-2 text-xl">
             <MorphoLogoSvg width={24} height={24} />

--- a/apps/fallback/src/components/header.tsx
+++ b/apps/fallback/src/components/header.tsx
@@ -1,12 +1,18 @@
 import { Button } from "@morpho-org/uikit/components/shadcn/button";
+import { useKeyedState } from "@morpho-org/uikit/hooks/use-keyed-state";
 import { cn } from "@morpho-org/uikit/lib/utils";
 import { XIcon } from "lucide-react";
 import { useState } from "react";
+import { useChains } from "wagmi";
 
-import { GITHUB_REPO_URL } from "@/lib/constants";
+import { CHAIN_DEPRECATION_DATES, GITHUB_REPO_URL } from "@/lib/constants";
 
-export function Header({ className, children, ...props }: React.ComponentProps<"div">) {
+export function Header({ className, children, chainId, ...props }: React.ComponentProps<"div"> & { chainId?: number }) {
   const [shouldShowBanner, setShouldShowBanner] = useState(true);
+  const [shouldShowDeprecationBanner, setShouldShowDeprecationBanner] = useKeyedState(true, chainId, { persist: true });
+  const chains = useChains();
+  const chainName = chains.find((chain) => chain.id === chainId)?.name;
+  const deprecationDate = chainId !== undefined ? CHAIN_DEPRECATION_DATES[chainId] : undefined;
 
   return (
     <div className="pointer-events-none fixed top-0 z-50 flex h-screen w-screen flex-col">
@@ -20,6 +26,17 @@ export function Header({ className, children, ...props }: React.ComponentProps<"
             </a>
           </span>
           <Button size="sm" variant="ghost" onClick={() => setShouldShowBanner(false)}>
+            <XIcon />
+          </Button>
+        </aside>
+      )}
+      {deprecationDate !== undefined && shouldShowDeprecationBanner && (
+        <aside className="pointer-events-auto flex items-center bg-amber-600 px-1 text-sm font-light italic">
+          <span className="grow py-2 text-center">
+            This fallback app will stop supporting {chainName ?? "this chain"} on {deprecationDate}. Withdraw your
+            positions or use an alternative interface before then.
+          </span>
+          <Button size="sm" variant="ghost" onClick={() => setShouldShowDeprecationBanner(false)}>
             <XIcon />
           </Button>
         </aside>

--- a/apps/fallback/src/lib/constants.ts
+++ b/apps/fallback/src/lib/constants.ts
@@ -1,5 +1,52 @@
+import { tac } from "@morpho-org/uikit/lib/chains";
+import {
+  abstract,
+  bsc,
+  celo,
+  corn,
+  etherlink,
+  fraxtal,
+  hemi,
+  ink,
+  lisk,
+  mode as modeMainnet,
+  scroll as scrollMainnet,
+  sei,
+  soneium,
+  sonic,
+  zircuit,
+} from "wagmi/chains";
+
 export const GITHUB_OWNER = "morpho-org";
 export const GITHUB_REPO = "morpho-lite-apps";
 export const GITHUB_REPO_URL = `https://github.com/${GITHUB_OWNER}/${GITHUB_REPO}`;
 
 export const TERMS_OF_USE = "https://cdn.morpho.org/documents/Morpho_Terms_of_Use.pdf";
+
+/**
+ * Chains scheduled to be removed from the fallback app, mapped to the date
+ * after which they will no longer be supported. Chains in this map show a
+ * deprecation banner with the given date; after the date, remove the chain
+ * from `wagmi-config.ts` entirely.
+ *
+ * Format: `[chainId]: "Month DD, YYYY"` (e.g. `"May 15, 2026"`)
+ */
+const DEPRECATION_DATE = "May 7, 2026";
+export const CHAIN_DEPRECATION_DATES: Record<number, string> = {
+  [abstract.id]: DEPRECATION_DATE,
+  [bsc.id]: DEPRECATION_DATE,
+  [celo.id]: DEPRECATION_DATE,
+  [corn.id]: DEPRECATION_DATE,
+  [etherlink.id]: DEPRECATION_DATE,
+  [fraxtal.id]: DEPRECATION_DATE,
+  [hemi.id]: DEPRECATION_DATE,
+  [ink.id]: DEPRECATION_DATE,
+  [lisk.id]: DEPRECATION_DATE,
+  [modeMainnet.id]: DEPRECATION_DATE,
+  [scrollMainnet.id]: DEPRECATION_DATE,
+  [sei.id]: DEPRECATION_DATE,
+  [soneium.id]: DEPRECATION_DATE,
+  [sonic.id]: DEPRECATION_DATE,
+  [tac.id]: DEPRECATION_DATE,
+  [zircuit.id]: DEPRECATION_DATE,
+};


### PR DESCRIPTION
## Summary
- Adds a dismissible amber banner (below the existing pink "emergencies" banner) warning that the fallback app will stop supporting chains that aren't migrating to the main Morpho app
- Banner text includes the chain name and the cutoff date, driven by a `CHAIN_DEPRECATION_DATES` map in `apps/fallback/src/lib/constants.ts` (currently populated with 16 non-full-support chains at `May 7, 2026` — adjust the date when the notice period begins)
- Dismissal is keyed per-chain via `useKeyedState` with `persist: true`, and the banner derives its chain from `selectedChainSlug` (passed from `page.tsx`) so it works without a connected wallet

## Test plan
- [ ] Load the fallback app, switch to a deprecated chain (e.g. BSC) — banner appears with chain name + date
- [ ] Dismiss, switch to another deprecated chain — banner re-appears
- [ ] Return to the previously dismissed chain — banner stays hidden
- [ ] Switch to a main-app-supported chain (Ethereum, Base, …) — no banner