### PR TITLE
ci(fallback): add Filebase IPFS deployment workflow

### DIFF
--- a/.github/workflows/filebase-deploy.yaml
+++ b/.github/workflows/filebase-deploy.yaml
@@ -1,0 +1,65 @@
+name: Deploy site via Filebase
+on:
+  push:
+    branches: ["release"]
+    paths:
+      - "pnpm-lock.yaml"
+      - "packages/uikit/**"
+      - "apps/fallback/**"
+      - ".github/workflows/filebase-deploy.yaml"
+
+permissions:
+  contents: read
+  pull-requests: write
+  statuses: write
+
+jobs:
+  deploy-to-filebase:
+    environment:
+      name: IPFS
+      url: https://morpho-fallback-app.myfilebase.site
+
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        node-version: [22]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Install pnpm
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        with:
+          version: 10
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "pnpm"
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Build fallback app
+        env:
+          VITE_IS_IPFS_BUILD: "true"
+        run: pnpm run fallback-app:build
+      - name: Upload CAR to Filebase
+        id: deploy
+        uses: ipshipyard/ipfs-deploy-action@266952049b3bf1bdc2afadcf568759e11ac1ef66 # v1.9.2
+        with:
+          path-to-deploy: apps/fallback/dist
+          filebase-access-key: ${{ secrets.FILEBASE_ACCESS_KEY }}
+          filebase-secret-key: ${{ secrets.FILEBASE_SECRET_KEY }}
+          filebase-bucket: ${{ secrets.FILEBASE_BUCKET }}
+          github-token: ${{ github.token }}
+      - name: Publish new CID to Filebase Site (IPNS)
+        env:
+          FILEBASE_ACCESS_KEY: ${{ secrets.FILEBASE_ACCESS_KEY }}
+          FILEBASE_SECRET_KEY: ${{ secrets.FILEBASE_SECRET_KEY }}
+          SITE_LABEL: morpho-fallback-app.myfilebase.site
+          CID: ${{ steps.deploy.outputs.cid }}
+        run: |
+          TOKEN=$(printf '%s' "${FILEBASE_ACCESS_KEY}:${FILEBASE_SECRET_KEY}" | base64 -w 0)
+          curl -fsS -X PUT \
+            -H "Authorization: Bearer ${TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d "{\"cid\":\"${CID}\"}" \
+            "https://api.filebase.io/v1/names/${SITE_LABEL}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,7 +204,8 @@ Same as Fallback, plus:
 ### Deployment
 
 - Lite app deploys to Vercel via `pnpm run deploy` in `apps/lite`
-- Both apps support Fleek deployment (via `@fleek-platform/cli`)
+- Fallback app deploys to IPFS via Filebase (see `.github/workflows/filebase-deploy.yaml`) — the action uploads a CAR to the bucket, then publishes the new CID to the Site's IPNS via the Filebase Platform API
+- Both apps still support Fleek deployment (via `@fleek-platform/cli`); the Fleek workflow will be removed once the Filebase pipeline is validated
 - Ensure SPA routing is configured (all routes → `index.html`)
 
 ### Development Workflow

--- a/apps/fallback/src/components/footer.tsx
+++ b/apps/fallback/src/components/footer.tsx
@@ -56,6 +56,8 @@ export function Footer() {
     return false;
   }, [ipfsDeployments]);
 
+  if (import.meta.env.VITE_IS_IPFS_BUILD === "true") return null;
+
   return (
     <div className="bg-primary fixed bottom-0 z-[51] h-[12px] w-full overflow-visible">
       <div

--- a/apps/fallback/src/vite-env.d.ts
+++ b/apps/fallback/src/vite-env.d.ts
@@ -3,6 +3,7 @@
 
 interface ImportMetaEnv {
   readonly VITE_WALLET_KIT_PROJECT_ID: string;
+  readonly VITE_IS_IPFS_BUILD?: string;
 }
 
 interface ImportMeta {

--- a/apps/fallback/vite.config.ts
+++ b/apps/fallback/vite.config.ts
@@ -8,6 +8,7 @@ import svgr from "vite-plugin-svgr";
 
 // https://vite.dev/config/
 export default defineConfig({
+  base: "./",
   plugins: [svgr(), tailwindcss(), react()],
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary

- Add `.github/workflows/filebase-deploy.yaml` that, on push to `release`, builds the fallback app, uploads it to a Filebase IPFS bucket as a CAR via [`ipshipyard/ipfs-deploy-action`](https://github.com/ipshipyard/ipfs-deploy-action), and publishes the new CID to the Filebase Site's IPNS so [`morpho-fallback-app.myfilebase.site`](https://morpho-fallback-app.myfilebase.site) auto-updates.
- Leave the existing Fleek workflow (`fleek-deploy.yaml`) untouched — it will be removed in a follow-up PR once Filebase is validated end-to-end. Both pipelines will run in parallel on the next release push.
- Wire up two small app changes that are required for any IPFS hosting (benefit both Fleek and Filebase):
  - `base: "./"` in `apps/fallback/vite.config.ts` — assets resolve correctly on path gateways like `ipfs.filebase.io/ipfs/<cid>/...`
  - `VITE_IS_IPFS_BUILD` flag hides the bottom-right "IPFS" info button when the build is IPFS-targeted (the button surfaces alternative IPFS deployments — meaningless when you're already on one)

## Required repo secrets (new)

Before the first run on `release`, add under `Settings → Secrets and variables → Actions`:

- `FILEBASE_ACCESS_KEY` — S3 access key from the Filebase console
- `FILEBASE_SECRET_KEY` — S3 secret key
- `FILEBASE_BUCKET` — bucket name (`morpho-fallback-app`)

The existing `FLEEK_TOKEN` / `FLEEK_PROJECT_ID` secrets stay in use for the Fleek workflow.

## Test plan

- [ ] CAR upload + IPNS publish validated locally against the production Site (CID `bafybeigsuzt4x7cme7lvphp6uzmzmv2r2xou7uvsnhvbdsf6rzodvbewpq` renders the app correctly on the path gateway, IPFS button hidden)
- [ ] Add the three `FILEBASE_*` secrets to the repo
- [ ] Merge, push to `release`, verify the workflow succeeds and `morpho-fallback-app.myfilebase.site` reflects the new CID
- [ ] Confirm the Fleek workflow still runs alongside and produces the same build
- [ ] Follow-up PR: remove Fleek workflow, config, CLI devDependency, and related lockfile entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)